### PR TITLE
using highlightElement instead of highlightBlock

### DIFF
--- a/lib/plugins/plugin.js
+++ b/lib/plugins/plugin.js
@@ -19,6 +19,6 @@ function highlight(el, binding) {
             el.textContent = binding.value;
         }
     
-        hljs.highlightBlock(el);
+        hljs.highlightElement(el);
     }
 }


### PR DESCRIPTION
using highlightElement instead of highlightBlock to keep supporting newer versions